### PR TITLE
Use digests for GH actions (part 2)

### DIFF
--- a/.github/workflows/base-static-csi-presubmit.yml
+++ b/.github/workflows/base-static-csi-presubmit.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - uses: ./.github/actions/presubmit-variant
         with:


### PR DESCRIPTION
Missed this file in https://github.com/cert-manager/base-images/pull/25